### PR TITLE
Detect test suite functions with omitted recevier variable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.0.11]
+
+- Support test suite functions that omit receiver variable name ([#12](https://github.com/babakks/vscode-go-test-suite/issues/12) thanks to [SimonRichardson](https://github.com/SimonRichardson)).
+
 ## [0.0.10]
 
 - Apply environment variables set by `go.testEnvVar` configuration parameter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-go-test-suite",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-go-test-suite",
-            "version": "0.0.10",
+            "version": "0.0.11",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.7.7"
             },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-go-test-suite",
     "displayName": "Go Test Suite Support",
     "description": "VS Code extension to click and run Go test functions written in third-party library formats",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "publisher": "babakks",
     "repository": {
         "type": "git",

--- a/src/goParser.ts
+++ b/src/goParser.ts
@@ -36,7 +36,7 @@ const _IMPORT_SINGLE_LINE_REGEXP = /^import (?:(.*?) )?"(.*?)"\r?$/;
 const _IMPORT_MULTI_LINE_START_REGEXP = /^import \(\r?$/;
 const _IMPORT_MULTI_LINE_END_REGEXP = /^\)\r?$/;
 const _IMPORT_MULTI_LINE_ENTRY_REGEXP = /^\s*(?:(.*?) )?"(.*?)"\r?$/;
-const _SUITE_TEST_FUNCTION_REGEXP = /^func \(.*? \*?(.*?)\) (Test.*?)\(.*? \*?(?:(.*?)\.)?(.*?)\) \{/;
+const _SUITE_TEST_FUNCTION_REGEXP = /^func \((?:.*? +)?\*?(.*?)\) (Test.*?)\(.*? \*?(?:(.*?)\.)?(.*?)\) \{/;
 
 const _GOCHECK_MODULE_NAME = 'gopkg.in/check.v1';
 const _GOCHECK_PACKAGE_NAME = 'check';

--- a/src/goParser.ts
+++ b/src/goParser.ts
@@ -191,3 +191,43 @@ export class GoParser {
         return result;
     }
 }
+
+export interface ParsedTestSuiteFunction {
+    index: number;
+    entireMatch: string;
+
+    /**
+     * For example, "SomeSuite" in "func (s *SomeSuite) TestSomething(c *gocheck.C)"
+     */
+    receiverType: string;
+
+    /**
+     * For example, "TestSomething" in "func (s *SomeSuite) TestSomething(c *gocheck.C)"
+     */
+    functionName: string;
+
+    /**
+     * For example, "gocheck" in "func (s *SomeSuite) TestSomething(c *gocheck.C)"
+     */
+    argTypeModule: string;
+
+    /**
+     * For example, "C" in "func (s *SomeSuite) TestSomething(c *gocheck.C)"
+     */
+    argTypeName: string;
+}
+
+export function parseSuiteTestFunction(line: string): ParsedTestSuiteFunction | undefined {
+    const match = _SUITE_TEST_FUNCTION_REGEXP.exec(line);
+    if (!match) {
+        return undefined;
+    }
+    return {
+        index: match.index,
+        entireMatch: match[0],
+        receiverType: match[1],
+        functionName: match[2],
+        argTypeModule: match[3],
+        argTypeName: match[4],
+    };
+}


### PR DESCRIPTION
This PR adds support for test suite functions that omit the receiver variable name, like this:

```go
func (*SomeSuite) TestSomething(c *gocheck.C) {
    // ...
}
```