### PR TITLE
🎁 Add test cancellation and launch configuration code-lens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.0.14]
+
+- Allow cancellation of test runs ([#17](https://github.com/babakks/vscode-go-test-suite/issues/17) thanks to [SimonRichardson](https://github.com/SimonRichardson))
+
 ## [0.0.13]
 
 - Use connection string instead of instrumentation key for telemetry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.0.14]
 
 - Allow cancellation of test runs ([#17](https://github.com/babakks/vscode-go-test-suite/issues/17) thanks to [SimonRichardson](https://github.com/SimonRichardson))
+- Add code lens to copy test function launch configuration.
 
 ## [0.0.13]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-go-test-suite",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-go-test-suite",
-            "version": "0.0.13",
+            "version": "0.0.14",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.7.7"
             },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,13 @@
         "commands": [
             {
                 "command": "vscode-go-test-suite._moveCursorAndExecuteTest",
-                "title": "_moveCursorAndExecuteTest"
+                "title": "_moveCursorAndExecuteTest",
+                "enablement": "false"
+            },
+            {
+                "command": "vscode-go-test-suite._showLaunchConfiguration",
+                "title": "_showLaunchConfiguration",
+                "enablement": "false"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-go-test-suite",
     "displayName": "Go Test Suite Support",
     "description": "VS Code extension to click and run Go test functions written in third-party library formats",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "publisher": "babakks",
     "repository": {
         "type": "git",

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,25 +1,72 @@
 import * as vscode from 'vscode';
+import { hasLaunchConfiguration, TestData, TestProvider } from './testProvider';
 
 export const COMMAND_MOVE_CURSOR_AND_EXEC_TEST = 'vscode-go-test-suite._moveCursorAndExecuteTest';
+export const COMMAND_SHOW_LAUNCH_CONFIGURATION = 'vscode-go-test-suite._showLaunchConfiguration';
 
-export function registerCommands(): vscode.Disposable[] {
+export function registerCommands(cmd: CommandsProvider): vscode.Disposable[] {
     return [
-        vscode.commands.registerCommand(COMMAND_MOVE_CURSOR_AND_EXEC_TEST, moveCursorAndExecuteTest),
+        vscode.commands.registerCommand(COMMAND_MOVE_CURSOR_AND_EXEC_TEST, cmd.moveCursorAndExecuteTest.bind(cmd)),
+        vscode.commands.registerCommand(COMMAND_SHOW_LAUNCH_CONFIGURATION, cmd.showLaunchConfiguration.bind(cmd)),
     ];
 }
 
-export function moveCursorAndExecuteTest(test: vscode.TestItem, mode: 'run' | 'debug') {
-    const editor = vscode.window.activeTextEditor;
-    if (!editor || editor.document.uri.toString() !== test.uri?.toString() || !test.range) {
-        return;
+export type MoveCursorAndExecuteTestParameters = Parameters<typeof CommandsProvider.prototype.moveCursorAndExecuteTest>;
+export type ShowLaunchConfigurationParameters = Parameters<typeof CommandsProvider.prototype.showLaunchConfiguration>;
+
+export class CommandsProvider {
+    constructor(readonly providers: TestProvider[]) { }
+
+    moveCursorAndExecuteTest(test: vscode.TestItem, mode: 'run' | 'debug') {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor || editor.document.uri.toString() !== test.uri?.toString() || !test.range) {
+            return;
+        }
+
+        const lastSelection = editor.selection;
+        editor.selection = new vscode.Selection(test.range.start, test.range.end);
+        if (mode === 'debug') {
+            vscode.commands.executeCommand('testing.debugAtCursor');
+        } else {
+            vscode.commands.executeCommand('testing.runAtCursor');
+        }
+        editor.selection = lastSelection;
     }
 
-    const lastSelection = editor.selection;
-    editor.selection = new vscode.Selection(test.range.start, test.range.end);
-    if (mode === 'debug') {
-        vscode.commands.executeCommand('testing.debugAtCursor');
-    } else {
-        vscode.commands.executeCommand('testing.runAtCursor');
+    private _findTestData(test: vscode.TestItem): [TestData, TestProvider] | undefined {
+        for (const provider of this.providers) {
+            const result = provider.getTestData(test);
+            if (result) {
+                return [result, provider];
+            }
+        }
     }
-    editor.selection = lastSelection;
+
+    async showLaunchConfiguration(test: vscode.TestItem) {
+        const hit = this._findTestData(test);
+        if (!hit) {
+            return;
+        }
+
+        const [testData, provider] = hit;
+        if (!hasLaunchConfiguration(testData)) {
+            return;
+        }
+
+        const launchConfiguration = await provider.getDebugLaunchConfiguration(test, testData);
+        if (!launchConfiguration) {
+            return;
+        }
+
+        const fullLaunchConfiguration = {
+            "version": "0.2.0",
+            "configurations": [
+                launchConfiguration
+            ],
+        };
+
+        const content = JSON.stringify(fullLaunchConfiguration, null, 4);
+        const doc = await vscode.workspace.openTextDocument({ language: "jsonc", content });
+        await vscode.window.showTextDocument(doc, { viewColumn: vscode.ViewColumn.Beside });
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import TelemetryReporter from '@vscode/extension-telemetry';
 import { mkdirSync } from 'fs';
 import * as vscode from 'vscode';
 import { ExecuteTestCodeLensProvider } from './codeLens';
-import { registerCommands } from './command';
+import { CommandsProvider, registerCommands } from './command';
 import { GocheckTestLibraryAdapter, QtsuiteTestLibraryAdapter, TelemetrySetup, TestProvider } from './testProvider';
 
 const _TELEMETRY_CONNECTION_STRING = 'InstrumentationKey=52da75ef-7ead-4f50-be55-f5644f9b7f4f;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=20ec7ba9-71fc-446e-a841-80c584d1292c';
@@ -27,7 +27,8 @@ export function activate(context: vscode.ExtensionContext) {
         ),
     );
 
-    context.subscriptions.push(...registerCommands());
+    const cmd = new CommandsProvider([gocheck.provider, qtsuite.provider]);
+    context.subscriptions.push(...registerCommands(cmd));
 
     vscode.commands.executeCommand('testing.refreshTests');
 }


### PR DESCRIPTION
This PR adds the ability to cancel running tests by clicking the stop button next to the running test's name in the "Test Results" pane.

Also, a new code lens action is added to copy the launch configuration for test functions. By clicking on the code lens action, a new document will be opened with the launch configuration in it. Users can copy the configuration to their `.vscode/launch.json` file and use it to manually invoke the debugger.

Fixes #17 