### PR TITLE
Support Go dot imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.0.16]
+
+- Support Golang dot imports ([#20](https://github.com/babakks/vscode-go-test-suite/issues/20) thanks to [tigarmo](https://github.com/tigarmo))
+
 ## [0.0.14]
 
 - Allow cancellation of test runs ([#17](https://github.com/babakks/vscode-go-test-suite/issues/17) thanks to [SimonRichardson](https://github.com/SimonRichardson))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-go-test-suite",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-go-test-suite",
-            "version": "0.0.15",
+            "version": "0.0.16",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.7.7"
             },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-go-test-suite",
     "displayName": "Go Test Suite Support",
     "description": "VS Code extension to click and run Go test functions written in third-party library formats",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "publisher": "babakks",
     "repository": {
         "type": "git",

--- a/src/test/local/goParser.test.ts
+++ b/src/test/local/goParser.test.ts
@@ -315,6 +315,19 @@ suite('GoParser', () => {
                     }]
                 },
                 {
+                    name: 'should detect `gocheck` suite test function (dot import)',
+                    content: 'func (s *SomeSuite) TestSomething(c *C) {}',
+                    imports: [{ lineNumber: 0, moduleName: 'gopkg.in/check.v1', alias: '.' }],
+                    expected: [{
+                        kind: 'gocheck',
+                        functionName: 'TestSomething',
+                        argType: { moduleName: 'gopkg.in/check.v1', typeName: 'C' },
+                        receiverType: 'SomeSuite',
+                        lineNumber: 0,
+                        range: [0, 0, 0, 41],
+                    }]
+                },
+                {
                     name: 'should detect `quicktest` suite test function (non-aliased import)',
                     content: 'func (s *SomeSuite) TestSomething(c *quicktest.C) {}',
                     imports: [{ lineNumber: 0, moduleName: 'github.com/frankban/quicktest' }],
@@ -338,6 +351,19 @@ suite('GoParser', () => {
                         receiverType: 'SomeSuite',
                         lineNumber: 0,
                         range: [0, 0, 0, 47],
+                    }]
+                },
+                {
+                    name: 'should detect `quicktest` suite test function (dot import)',
+                    content: 'func (s *SomeSuite) TestSomething(c *C) {}',
+                    imports: [{ lineNumber: 0, moduleName: 'github.com/frankban/quicktest', alias: '.' }],
+                    expected: [{
+                        kind: 'quicktest',
+                        functionName: 'TestSomething',
+                        argType: { moduleName: 'github.com/frankban/quicktest', typeName: 'C' },
+                        receiverType: 'SomeSuite',
+                        lineNumber: 0,
+                        range: [0, 0, 0, 41],
                     }]
                 },
                 {
@@ -375,6 +401,58 @@ suite('GoParser', () => {
                             receiverType: 'SomeSuiteB',
                             lineNumber: 1,
                             range: [1, 0, 1, 44],
+                        }
+                    ]
+                },
+                {
+                    name: 'should detect suite test function correctly if one module is dot imported (`gocheck`)',
+                    content: 'func (s *SomeSuiteA) TestA(c *C) {}\nfunc (s *SomeSuiteB) TestB(c *quicktest.C) {}',
+                    imports: [
+                        { lineNumber: 0, moduleName: 'github.com/frankban/quicktest' },
+                        { lineNumber: 1, moduleName: 'gopkg.in/check.v1', alias: '.' }
+                    ],
+                    expected: [
+                        {
+                            kind: 'gocheck',
+                            functionName: 'TestA',
+                            argType: { moduleName: 'gopkg.in/check.v1', typeName: 'C' },
+                            receiverType: 'SomeSuiteA',
+                            lineNumber: 0,
+                            range: [0, 0, 0, 34],
+                        },
+                        {
+                            kind: 'quicktest',
+                            functionName: 'TestB',
+                            argType: { moduleName: 'github.com/frankban/quicktest', typeName: 'C' },
+                            receiverType: 'SomeSuiteB',
+                            lineNumber: 1,
+                            range: [1, 0, 1, 44],
+                        }
+                    ]
+                },
+                {
+                    name: 'should detect suite test function correctly if one module is dot imported (`quicktest`)',
+                    content: 'func (s *SomeSuiteA) TestA(c *C) {}\nfunc (s *SomeSuiteB) TestB(c *check.C) {}',
+                    imports: [
+                        { lineNumber: 0, moduleName: 'github.com/frankban/quicktest' , alias: '.'},
+                        { lineNumber: 1, moduleName: 'gopkg.in/check.v1' }
+                    ],
+                    expected: [
+                        {
+                            kind: 'quicktest',
+                            functionName: 'TestA',
+                            argType: { moduleName: 'github.com/frankban/quicktest', typeName: 'C' },
+                            receiverType: 'SomeSuiteA',
+                            lineNumber: 0,
+                            range: [0, 0, 0, 34],
+                        },
+                        {
+                            kind: 'gocheck',
+                            functionName: 'TestB',
+                            argType: { moduleName: 'gopkg.in/check.v1', typeName: 'C' },
+                            receiverType: 'SomeSuiteB',
+                            lineNumber: 1,
+                            range: [1, 0, 1, 40],
                         }
                     ]
                 },


### PR DESCRIPTION
This PR adds support for Go dot imports, like:

```go
package foo

import (
    . "gopkg.in/check.v1"
)
```

Thanks to @tigarmo for reporting this.

Fixes #20